### PR TITLE
ヘッダーにグループ名とユーザー名が表示されるようにする２

### DIFF
--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -4,9 +4,9 @@
       %h2.main-header__left-box__current-group
         = @group.name
       %ul.main-header__left-box__member-list
-        Member :
+        Member:
         - @group.users.each do |user|
-          %li = user.name
+          = user.name
     .main-header__edit-btn
       =link_to "#", class: "edit-btn" do
         %p.edit-btn__edit-item


### PR DESCRIPTION
＃What
確認した際、メンバー名前が表示されていなかった為、修正しました。

＃Why
コードレビュー依頼