### PR TITLE
フォームが送信されたらイベントが発火させる

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,2 +1,6 @@
 $(function(){
+  $('#new_message').on('submit', function(e){
+    console.log('hoge');
+    e.preventDefault()
+  });
 });


### PR DESCRIPTION
＃What
message.js を編集した
＞formにイベントをセットした
＞非同期通信を行うために、preventDefault()を使用してデフォルトのイベントを止めた

＞console.log("hoge")を用いて、フォームが送信されたときにイベントが発火しているかどうかを確認した。

＃Why
