### PR TITLE
作成したHTMLをメッセージ全体の一番下に追加

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -53,7 +53,8 @@ $('#new_message').on('submit', function(e){
  })
   .done(function(data){
     var html = buildHTML(data);
-  
+    $('.message').append(html);
+    $('form')[0].reset();
   })
 })
 });


### PR DESCRIPTION
#What
>受け取ったHTMLを、appendメソッドによって.messageというクラスが適用されているdiv要素の子要素の一番最後に追加した。
>フォームを空にする処理を記述。
$('form')[0].reset();

>console.logを用いて、定義したHTMLの構造が意図しているものになっているか確認した。

#Why